### PR TITLE
Use cross-platform node's path.sep

### DIFF
--- a/walkdir.js
+++ b/walkdir.js
@@ -121,9 +121,9 @@ function walkdir(path,options,cb){
         return;     
       }
 
-      if(path == '/') path='';
+      if(path == _path.sep) path='';
       for(var i=0,j=files.length;i<j;i++){
-        statter(path+'/'+files[i],false,(depth||0)+1);
+        statter(path+_path.sep+files[i],false,(depth||0)+1);
       }
 
     };


### PR DESCRIPTION
Hi Ryan, I've changed your script to use cross-platform path separator to make it work on Windows more smoothly. 
