### PR TITLE
path.sep -> path.join for nodejs v0.4 support

### DIFF
--- a/walkdir.js
+++ b/walkdir.js
@@ -121,9 +121,9 @@ function walkdir(path,options,cb){
         return;     
       }
 
-      if(path == _path.sep) path='';
+      if(_path.basename(path).length == 0) path='';
       for(var i=0,j=files.length;i<j;i++){
-        statter(path+_path.sep+files[i],false,(depth||0)+1);
+        statter(_path.join(path, files[i]),false,(depth||0)+1);
       }
 
     };


### PR DESCRIPTION
You are right, in order to make #12 support old nodejs, we should use path.join. 
Must work now, take a look.
