### PR TITLE
Duplicate inode entries in Windows (NTFS)

### DIFF
--- a/walkdir.js
+++ b/walkdir.js
@@ -74,8 +74,10 @@ function walkdir(path,options,cb){
 
 
       //if i have evented this inode already dont again.
-      if(inos[stat.dev+'-'+stat.ino] && stat.ino) return;
-      inos[stat.dev+'-'+stat.ino] = 1;
+      var fileName = _path.basename(path);
+      var fileKey = stat.dev + '-' + stat.ino + '-' + fileName;
+      if(inos[fileKey] && stat.ino) return;
+      inos[fileKey] = 1;
 
       if (first && stat.isDirectory()) {
         emitter.emit('targetdirectory',path,stat,depth);


### PR DESCRIPTION
There were many cases, when two or even more files in one directory had the same inode. For example:
-863777672-21392098230827184 // left_panel_page_step.js
-863777672-21392098230827184 // main_menu_step.js
These files had different modification and creation times, different sizes, but exact the same inode key.
I suggest to include a file name in a key.