### PR TITLE
Fix types for walk.sync(dir, cb)

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -62,4 +62,7 @@ j.splice(0)
 let k = walkdir.sync('',{return_object:true})
 k[Object.keys(k)[0]].isDirectory()
 
-
+let l = walkdir.sync('',(path)=>{
+    path.substr
+})
+l.splice(0)

--- a/walkdir.d.ts
+++ b/walkdir.d.ts
@@ -177,6 +177,7 @@ declare namespace walkdir {
     export function sync(path:string,options:walkdir.WalkOptions&{return_object:true},eventListener?:walkdir.WalkEventListener):{[path:string]:Stats};
     export function sync(path:string,options?:walkdir.WalkOptions&{return_object?:false},eventListener?:walkdir.WalkEventListener):string[];
     export function sync(path:string,options?:walkdir.WalkOptions&{return_object?:boolean},eventListener?:walkdir.WalkEventListener):string[]|{[path:string]:Stats};
+    export function sync(path:string,eventListener?:walkdir.WalkEventListener):string[];
 
     // always sync:false. a promise of whatever is the same as walkdir.
     export function async(path:string,options:walkdir.WalkOptions&{return_object:true},eventListener?:walkdir.WalkEventListener):Promise<{[path:string]:Stats}>;


### PR DESCRIPTION
Hi! Thanks for the library.

This call signature is documented and is working. I updated the types to reflect it.